### PR TITLE
Convert launch configuration to launch template due to it being phased out by AWS. 

### DIFF
--- a/launch_configuration.tf
+++ b/launch_configuration.tf
@@ -1,9 +1,0 @@
-resource "aws_launch_configuration" "launch_config" {
-  name                        = "launch_config"
-  image_id                    = data.aws_ssm_parameter.instance_ami.value
-  instance_type               = var.instance_type
-  security_groups             = [aws_security_group.instance_sg.id]
-  associate_public_ip_address = true
-  user_data                   = file("userdata.sh")
-  key_name                    = var.keyname
-}

--- a/launch_template.tf
+++ b/launch_template.tf
@@ -1,0 +1,13 @@
+resource "aws_launch_template" "launch_template" {
+  name                = "launch_template"
+  image_id           = data.aws_ssm_parameter.instance_ami.value
+  instance_type      = var.instance_type
+  
+  network_interfaces {
+    associate_public_ip_address = true
+    security_groups            = [aws_security_group.instance_sg.id]
+  }
+
+  user_data = base64encode(file("userdata.sh"))
+  key_name  = var.keyname
+}


### PR DESCRIPTION
Terraform cant deploy the resources, especially on AWS accounts that have completely replaced launch configuration with Launch template

@chineduituma1 @OGilgalson 